### PR TITLE
Support raw URL sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apt-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/reader-test.js
+++ b/test/reader-test.js
@@ -20,7 +20,7 @@ function packagesgz() {
   nock('http://deb.debian.org/', {"encodedQueryParams":true})
     .get('/debian/dists/buster/main/binary-all/Packages')
     .reply(400);
-  
+
   nock('http://deb.debian.org/', {"encodedQueryParams":true})
     .get('/debian/dists/buster/main/binary-all/Packages.gz')
     .reply(200, PackagesGZ);
@@ -36,7 +36,7 @@ function sourcesgz() {
   nock('http://deb.debian.org/', {"encodedQueryParams":true})
     .get('/debian/dists/buster/main/source/Sources')
     .reply(400);
-  
+
   nock('http://deb.debian.org/', {"encodedQueryParams":true})
     .get('/debian/dists/buster/main/source/Sources.gz')
     .reply(200, SourcesGZ);
@@ -46,25 +46,31 @@ const { readAptSource } = require('../dist/aptreader');
 
 describe('read and parse debian repository', () => {
   afterEach(() => nock.restore());
-  
+
   it('should return binary package info from plaintext index', async function() {
     this.timeout(20000);
     packages();
     await readAptSource('deb http://deb.debian.org/debian buster main');
   });
-  
+
+  it('should return binary package info from plaintext index and raw URL', async function () {
+    this.timeout(20000);
+    packages();
+    await readAptSource('http://deb.debian.org/debian/dists/buster/main/binary-all/Packages');
+  });
+
   it('should return binary package info from gzipped index', async function() {
     this.timeout(20000);
     packagesgz();
     await readAptSource('deb http://deb.debian.org/debian buster main');
   });
-  
+
   it('should return source package info from plaintext index', async function() {
     this.timeout(20000);
     sources();
     await readAptSource('deb-src http://deb.debian.org/debian buster main');
   });
-    
+
   it('should return source package info from gzipped index', async function() {
     this.timeout(20000);
     sourcesgz();


### PR DESCRIPTION
Hey there - I'm trying to use this package with a APT repository that doesn't follow the normal URL path convention - the Packages file is actually hosted on the root of the URL.

Right now there is no way to manually specify a raw URL if you know it. I think it would be nice to have this feature, so I made this PR.